### PR TITLE
Backport 1.8 commands for 1.4.{11,12} to 1.6/1.7

### DIFF
--- a/cfg/1.6/master.yaml
+++ b/cfg/1.6/master.yaml
@@ -731,7 +731,7 @@ groups:
       
     - id: 1.4.11
       text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
-      audit: ps -ef | grep $etcdbin | grep -v grep | sed 's%.*data-dir[= ]\(\S*\)%\1%' | xargs stat -c %a
+      audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %a
       tests:
         test_items:
         - flag: "700"
@@ -748,7 +748,7 @@ groups:
 
     - id: 1.4.12
       text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
-      audit: ps -ef | grep $etcdbin | grep -v grep | sed 's%.*data-dir[= ]\(\S*\)%\1%' | xargs stat -c %U:%G
+      audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
       tests:
         test_items:
         - flag: "etcd:etcd"

--- a/cfg/1.7/master.yaml
+++ b/cfg/1.7/master.yaml
@@ -793,7 +793,7 @@ groups:
       
     - id: 1.4.11
       text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
-      audit: ps -ef | grep $etcdbin | grep -v grep | sed 's%.*data-dir[= ]\(\S*\)%\1%' | xargs stat -c %a
+      audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %a
       tests:
         test_items:
         - flag: "700"
@@ -810,7 +810,7 @@ groups:
 
     - id: 1.4.12
       text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
-      audit: ps -ef | grep $etcdbin | grep -v grep | ed 's%.*data-dir[= ]\(\S*\)%\1%' | xargs stat -c %U:%G
+      audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
       tests:
         test_items:
         - flag: "etcd:etcd"


### PR DESCRIPTION
Backport the command lines used to implement tests 1.4.11, 1.4.12 back
to 1.6/1.7. This generally improves them so they don't pick up the
apiserver command line, and also fixes a typo on 1.7 where it was using
ed instead of sed.