### PR TITLE
Add additional binary names to the openshift config.

### DIFF
--- a/cfg/rh-0.7/config.yaml
+++ b/cfg/rh-0.7/config.yaml
@@ -6,11 +6,14 @@ master:
     bins:
       - openshift start master api
       - hypershift openshift-kube-apiserver
+      - hyperkube kube-apiserver
+      - kube-apiserver
 
   scheduler:
     bins:
       - "openshift start master controllers"
       - "hyperkube kube-scheduler"
+      - "kube-scheduler"
     confs:
       - /etc/origin/master/scheduler.json
 
@@ -18,10 +21,15 @@ master:
     bins:
       - "openshift start master controllers"
       - "hypershift openshift-controller-manager"
+      - "hyperkube controller-manager"
+      - "hyperkube kube-controller-manager"
+      - "kube-controller"
+      - "kube-controller-manager"
 
   etcd:
     bins:
       - openshift start etcd
+      - etcd
 
 node:
   svcs:


### PR DESCRIPTION
Fix for https://sysdig.atlassian.net/browse/SSPROD-5416 (https://sysdig.atlassian.net/browse/ESC-275 and https://sysdig.atlassian.net/browse/ESC-368 are related).

Openshift 4.3 and 4.4 use different process invocations than 3.X, which stops kube-bench from running. This PR adds the missing process names to check. Verified for 4.3 and 4.4, and 4.5. ~need to verify for 4.5 before merging~

Agent PR: https://github.com/draios/agent/pull/2282