### PR TITLE
Correctly detect openshift masters.

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -25,6 +25,9 @@ master:
       - "hyperkube apiserver"
       - "hyperkube kube-apiserver"
       - "apiserver"
+      # Required to correctly detect the master node in openshift
+      - "openshift start master api"
+      - "hypershift openshift-kube-apiserver"
     confs:
       - /etc/kubernetes/manifests/kube-apiserver.yaml
       - /etc/kubernetes/manifests/kube-apiserver.yml
@@ -39,6 +42,8 @@ master:
       - "hyperkube scheduler"
       - "hyperkube kube-scheduler"
       - "scheduler"
+      # Required to correctly detect the master node in openshift
+      - "openshift start master controllers"
     confs:
       - /etc/kubernetes/manifests/kube-scheduler.yaml
       - /etc/kubernetes/manifests/kube-scheduler.yml
@@ -57,6 +62,9 @@ master:
       - "hyperkube controller-manager"
       - "hyperkube kube-controller-manager"
       - "controller-manager"
+      # Required to correctly detect the master node in openshift
+      - "openshift start master controllers"
+      - "hypershift openshift-controller-manager"
     confs:
       - /etc/kubernetes/manifests/kube-controller-manager.yaml
       - /etc/kubernetes/manifests/kube-controller-manager.yml
@@ -72,6 +80,8 @@ master:
     optional: true
     bins:
       - "etcd"
+      # Required to correctly detect the master node in openshift
+      - "openshift start etcd"
     confs:
       - /etc/kubernetes/manifests/etcd.yaml
       - /etc/kubernetes/manifests/etcd.yml


### PR DESCRIPTION
kube-bench does not use the schema specific config overrides to detect master vs node, which is breaking on openshift (openshift is the only schema that uses custom config overrides)

When determining master vs node, kube-bench uses the master processes **purely** from /cfg/config.yaml to determine if it is running on a master or a node, and then uses the merged config from /cfg/config.yaml and the schema specific config to run the actual tests.

This PR adds the openshift master processes to the list of processes that are used to determine master vs node.