### PR TITLE
fix: Add openshift process names (SMAGENT-3167)

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -28,6 +28,7 @@ master:
       - "apiserver"
       - "openshift start master api"
       - "hypershift openshift-kube-apiserver"
+      - "service-catalog apiserver"
     confs:
       - /etc/kubernetes/manifests/kube-apiserver.yaml
       - /etc/kubernetes/manifests/kube-apiserver.yml
@@ -67,6 +68,7 @@ master:
       - "controller-manager"
       - "openshift start master controllers"
       - "hypershift openshift-controller-manager"
+      - "service-catalog controller-manager"
     confs:
       - /etc/kubernetes/manifests/kube-controller-manager.yaml
       - /etc/kubernetes/manifests/kube-controller-manager.yml


### PR DESCRIPTION
Execing into the nodes from https://sysdig.atlassian.net/browse/SMAGENT-3167 shows that the apiserver and controller-manager are running under different process names.