### PR TITLE
(fix) Incorrect Warn

### DIFF
--- a/cfg/eks-1.0/node.yaml
+++ b/cfg/eks-1.0/node.yaml
@@ -336,7 +336,6 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
 
       - id: 3.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Scored)"


### PR DESCRIPTION
Remove `scored: false` from control 3.2.9