### PR TITLE
(fix) Incorrect Warn update

### DIFF
--- a/cfg/eks-1.0/node.yaml
+++ b/cfg/eks-1.0/node.yaml
@@ -336,6 +336,7 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
+        scored: true
 
       - id: 3.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Scored)"


### PR DESCRIPTION
Update to https://github.com/draios/kube-bench/pull/18, scored should be set to true, not removed completely 