### PR TITLE
Fix rh-1.0 control 4.2.10

### DIFF
--- a/cfg/rh-1.0/node.yaml
+++ b/cfg/rh-1.0/node.yaml
@@ -364,7 +364,7 @@ groups:
       - id: 4.2.10
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
         audit: |
-          oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.kubeletClientInfo'
+          oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.kubeletClientInfo // .apiServerArguments'
         tests:
           bin_op: and
           test_items:


### PR DESCRIPTION
Control 4.2.10 was giving false positives on OpenShift 4.8.41. From the hardening guide, since v4.6, these configuration values are under a different key. 

Fix validated in OpenShift 4.7.53