### PR TITLE
chore: Bump Golang to fix vulns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/kube-bench
 
-go 1.13
+go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.35.28
@@ -25,7 +25,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
-	golang.org/x/text v0.3.8 // indirect
+	golang.org/x/text v0.4.0 // indirect
 	google.golang.org/appengine v1.5.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b


### PR DESCRIPTION
Updates the Golang version and the `text` package version to address vulns. See https://sysdig.atlassian.net/browse/SSPROD-19103 for details.