### PR TITLE
[OP-361] Update golang to 1.24.13 due to vulnerabilities detected

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.3.0
         with:
-          go-version: 1.24.11
+          go-version: 1.24.13
       - name: Checkout code
         uses: actions/checkout@v4.2.2
       - name: yaml-lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.3.0
         with:
-          go-version: 1.24.11
+          go-version: 1.24.13
       - name: Checkout code
         uses: actions/checkout@v4.2.2
       - name: Run unit tests

--- a/Dependency-Dockerfile
+++ b/Dependency-Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.11 AS builder
+FROM golang:1.24.13 AS builder
 
 ENV OUTPUT_DIR=/out
 ENV KUBECTL_VERSION="v1.31.4"

--- a/Dependency-Dockerfile_linux_arm64
+++ b/Dependency-Dockerfile_linux_arm64
@@ -1,4 +1,4 @@
-FROM golang:1.24.11 AS builder
+FROM golang:1.24.13 AS builder
 
 ENV OUTPUT_DIR=/out
 ENV KUBECTL_VERSION="v1.31.4"

--- a/Dependency-Dockerfile_linux_s390x
+++ b/Dependency-Dockerfile_linux_s390x
@@ -1,4 +1,4 @@
-FROM golang:1.24.11 AS builder
+FROM golang:1.24.13 AS builder
 
 ENV OUTPUT_DIR=/out
 ENV KUBECTL_VERSION="v1.31.4"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.11 AS build
+FROM golang:1.24.13 AS build
 WORKDIR /go/src/github.com/aquasecurity/kube-bench/
 COPY go.mod go.sum ./
 COPY main.go .


### PR DESCRIPTION
### Basic info

- **JIRA issue**: https://sysdig.atlassian.net/browse/OP-361

### Description

- Update golang to 1.24.13

