### PR TITLE
fix: bump golang 1.25.9 → 1.25.10 in Dependency-Dockerfile

### DIFF
--- a/Dependency-Dockerfile
+++ b/Dependency-Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9 AS builder
+FROM golang:1.25.10 AS builder
 
 ENV OUTPUT_DIR=/out
 ENV KUBECTL_VERSION="v1.31.4"


### PR DESCRIPTION
## Context

The `compliance-benchmark-runner` image in `draios/secure-backend` embeds the `kube-bench` binary. The current `Dependency-Dockerfile` uses `golang:1.25.9` which has known CVEs flagged by the Sysdig vulnerability scanner (1 fixable High).

The scanner recommends upgrading to `golang:1.25.10`.

## Change

`golang:1.25.9` → `golang:1.25.10` in `Dependency-Dockerfile`.

Once this is merged and a new `kube-bench-dependency` image is published, the `KUBE_BENCH_TAG` in `compliance/cmd/benchmark-runner/Dockerfile` (secure-backend) can be bumped to pick up the fix.