### PR TITLE
fix: bump Go to 1.25.11 to clear HIGH CVEs in kube-bench-dependency [DEVX-3134]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.3.0
         with:
-          go-version: 1.25.9
+          go-version: 1.25.11
       - name: Checkout code
         uses: actions/checkout@v4.2.2
       - name: yaml-lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.3.0
         with:
-          go-version: 1.25.9
+          go-version: 1.25.11
       - name: Checkout code
         uses: actions/checkout@v4.2.2
       - name: Run unit tests

--- a/Dependency-Dockerfile
+++ b/Dependency-Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.10 AS builder
+FROM golang:1.25.11 AS builder
 
 ENV OUTPUT_DIR=/out
 ENV KUBECTL_VERSION="v1.31.4"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9 AS build
+FROM golang:1.25.11 AS build
 WORKDIR /go/src/github.com/aquasecurity/kube-bench/
 COPY go.mod go.sum ./
 COPY main.go .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/kube-bench
 
-go 1.25.9
+go 1.25.11
 
 require (
 	github.com/aws/aws-sdk-go v1.55.8


### PR DESCRIPTION
## Proposed changes

The `kube-bench-dependency` image (consumed by `secure-backend`'s `compliance-benchmark-runner` via `KUBE_BENCH_TAG`) embeds a `kube-bench` binary built with **Go 1.25.10**. The Sysdig `secure-components-vuln-check` scan policy fails on two HIGH, network-vector, fixable Go runtime CVEs, blocking the compliance chart PR (secure-backend #57131):

- **CVE-2026-27145** — fixed in Go 1.25.11
- **CVE-2026-42504** — fixed in Go 1.25.11

### Fix
Bump all Go references to **1.25.11**:

| File | Change | Why |
|---|---|---|
| `Dependency-Dockerfile` | `golang:1.25.10 → 1.25.11` | **The actual fix** — this builder produces the scanned `kube-bench-dependency` binary |
| `Dockerfile` | `golang:1.25.9 → 1.25.11` | consistency |
| `go.mod` | `go 1.25.9 → 1.25.11` | language version alignment |
| `.github/workflows/build.yml` | `go-version: 1.25.9 → 1.25.11` | keep CI runner ≥ go.mod (avoids GOTOOLCHAIN failure) |
| `.github/workflows/release.yml` | `go-version: 1.25.9 → 1.25.11` | same |

### Follow-up (after merge)
1. Run the `secure/compliance/compliance-kube-bench` Jenkins job to rebuild and publish a new `kube-bench-dependency` tag (e.g. `1.2.0.7`).
2. In `secure-backend`, bump `KUBE_BENCH_TAG` in `compliance/cmd/benchmark-runner/Dockerfile` to that new tag (tracked in compliance PR #57131).

🤖 Generated with [Claude Code](https://claude.com/claude-code)